### PR TITLE
ライブラリアップデート

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-	id("org.springframework.boot") version "2.5.6" apply false
+	id("org.springframework.boot") version "2.6.1" apply false
 	id("io.spring.dependency-management") version "1.0.11.RELEASE"
 	id("io.gitlab.arturbosch.detekt") version "1.18.1"
 	kotlin("jvm") version "1.6.0"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,8 +4,8 @@ plugins {
 	id("org.springframework.boot") version "2.5.6" apply false
 	id("io.spring.dependency-management") version "1.0.11.RELEASE"
 	id("io.gitlab.arturbosch.detekt") version "1.18.1"
-	kotlin("jvm") version "1.5.31"
-	kotlin("plugin.spring") version "1.5.31" apply false
+	kotlin("jvm") version "1.6.0"
+	kotlin("plugin.spring") version "1.6.0" apply false
 }
 
 group = "cypher"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
 	id("org.springframework.boot") version "2.6.1" apply false
 	id("io.spring.dependency-management") version "1.0.11.RELEASE"
-	id("io.gitlab.arturbosch.detekt") version "1.18.1"
+	id("io.gitlab.arturbosch.detekt") version "1.19.0"
 	kotlin("jvm") version "1.6.0"
 	kotlin("plugin.spring") version "1.6.0" apply false
 }
@@ -17,14 +17,14 @@ repositories {
 }
 
 detekt {
-	toolVersion = "1.18.1"
+	toolVersion = "1.19.0"
 	buildUponDefaultConfig = true
 	allRules = false
 	config = files("$projectDir/detekt/detekt.yml")
 }
 
 dependencies {
-	detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.18.1")
+	detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.19.0")
 }
 
 tasks.withType<io.gitlab.arturbosch.detekt.Detekt> {


### PR DESCRIPTION
### やったこと

- Kotlin v1.5.31 -> v.1.6.0
- Spring Boot v.2.5.6 -> v.2.6.1
- detekt v.1.18.1 -> 1.19.0

### やらなかったこと

### エビデンス
動作を確認

![image](https://user-images.githubusercontent.com/16466322/145699510-32e1dd14-4f33-43db-8522-fe193f5e95f2.png)

### 特にレビューして欲しい点

### その他
